### PR TITLE
Add Wii Classic Controller support via STEMMA QT I2C

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ add_executable(wili8jam
     src/gfx.c
     src/input.c
     src/audio.c
+    src/wiipad.c
     src/p8_preprocess.c
     src/p8_api.c
     src/p8_sfx.c

--- a/PLAN_NOTES.md
+++ b/PLAN_NOTES.md
@@ -1,0 +1,140 @@
+# Plan: I2C Wii Nunchuck Adapter Support
+
+Adds support for the Adafruit Wii Nunchuck Breakout Adapter (#4836) plugged into the
+Fruit Jam's STEMMA QT port. Allows use of NES Classic, SNES Classic, Wii Classic, and
+other Wii-protocol controllers alongside or instead of a USB gamepad. 
+Based on pico-infonesPlus-main https://github.com/fhoedemakers/pico-infonesPlus
+
+## Hardware Context
+
+The Fruit Jam's STEMMA QT connector is on **i2c0, GPIO 20 (SDA) / GPIO 21 (SCL)** —
+the same bus already used by the TLV320DAC3100 audio codec (address 0x18). The Wii
+adapter lives at address **0x52**. Since the codec only uses I2C during `audio_init()`
+at boot (no runtime I2C writes), there is no bus contention during gameplay. The 100 kHz
+speed already configured by `audio_init()` is fully compatible with the Wii protocol —
+no re-initialization of the bus is needed.
+
+## Files to Change
+
+| File | Change |
+|------|--------|
+| `src/wiipad.c` | New — self-contained Wii controller driver |
+| `src/wiipad.h` | New — public API for the driver |
+| `src/input.c` | Add `input_wiipad_update()` call inside `input_update()` |
+| `src/input.h` | Expose `input_wiipad_init()` and USB controller count poll setter |
+| `src/main.cpp` | Call `input_wiipad_init()` after `audio_init()`; register poll lambda |
+| `CMakeLists.txt` | Add `src/wiipad.c` to source list |
+
+No new library dependencies — `hardware_i2c` is already linked.
+
+---
+
+## Step 1 — New file: `src/wiipad.c` + `src/wiipad.h`
+
+A self-contained driver with three responsibilities.
+
+### A. Initialization
+
+Called once after `audio_init()` so i2c0 is already live. Does not call `i2c_init()`
+again — just reuses the existing bus.
+
+1. Write `0x55` to register `0xF0` — disables encryption (modern init sequence)
+2. Write `0x00` to register `0xFB` — puts the controller in unencrypted data mode
+3. Track a `connected` boolean; if `i2c_write_timeout_us()` returns an error, mark not
+   connected and retry every ~60 frames
+
+### B. Per-frame read
+
+Called from `input_update()` once per frame.
+
+1. Write `0x00` to request a data burst
+2. Short delay (~100 µs)
+3. Read 6 bytes
+4. Decode the 6-byte Classic Controller packet (standard WiiBrew format) into
+   directional + button bits
+5. Return decoded button state
+
+### C. Button mapping to PICO-8
+
+| Wii Classic button | PICO-8 button |
+|--------------------|---------------|
+| D-pad left         | btn 0 (left)  |
+| D-pad right        | btn 1 (right) |
+| D-pad up           | btn 2 (up)    |
+| D-pad down         | btn 3 (down)  |
+| A                  | btn 4 (O)     |
+| B                  | btn 5 (X)     |
+| Plus (+) / Start   | btn 6 (menu)  |
+
+NES Classic: A→O, B→X, Start→menu.
+SNES Classic: A→O, B→X, Start→menu. (X/Y/L/R have no PICO-8 equivalent in the
+6-button model, but could optionally alias to O/X if desired later.)
+
+---
+
+## Step 2 — Modify `src/input.c`
+
+Add `input_wiipad_update()` inside `input_update()`, after `tuh_task()` and before the
+btnp counter loop. It:
+
+1. Calls the wiipad driver to get current button state
+2. Determines player assignment:
+   - **No USB controller connected** → wiipad = player 1
+   - **USB controller connected** → wiipad = player 2
+   - Detection via a registered poll function (see step 3)
+3. Calls `key_set()` / `key_clear()` on the appropriate virtual keycodes
+   (`VKEY_GP1_*` or `VKEY_GP2_*`) in `key_state[]`
+
+This slots into the existing architecture — no new Lua API, no changes to `input_btn()`
+or `input_btnp()`. The wiipad just feeds into the same keycode bitfield as USB gamepads
+and the keyboard, so btnp auto-repeat works for free.
+
+To avoid a circular dependency (input.c does not know about `obUSBHost`), add a small
+**USB controller count poll function pointer** using the same pattern already established
+for mouse and modifier polling (`input_set_mouse_poll`, `input_set_modifier_poll`).
+
+---
+
+## Step 3 — Modify `src/input.h`
+
+Expose:
+
+```c
+void input_wiipad_init(void);
+void input_set_usb_controller_count_poll(int (*fn)(void));
+```
+
+---
+
+## Step 4 — Modify `src/main.cpp`
+
+After `audio_init()`:
+
+1. Call `input_wiipad_init()` and log whether a controller was detected
+2. Register the USB controller count poll lambda (mirrors the mouse/modifier lambdas
+   already present):
+
+```cpp
+input_set_usb_controller_count_poll([]() -> int {
+    return obUSBHost.m_obHID.getControllerCount()
+         + obUSBHost.m_obXInput.getMountedCount();
+});
+```
+
+---
+
+## Step 5 — Modify `CMakeLists.txt`
+
+Add `src/wiipad.c` to the `add_executable(wili8jam ...)` source list.
+
+---
+
+## Edge Cases
+
+- **No controller at boot**: init fails gracefully, periodic retry every ~60 frames
+- **Controller unplugged and replugged**: re-detected on next retry cycle
+- **Two Wii controllers**: the STEMMA QT port is a single I2C bus, so only one adapter
+  at a time. A second Wii controller would require a separate I2C bus or an I2C
+  multiplexer — out of scope.
+- **Bus conflict during audio init**: `input_wiipad_init()` is called after
+  `audio_init()` completes, so the codec sequence is fully done before touching the bus.

--- a/src/input.c
+++ b/src/input.c
@@ -1,4 +1,5 @@
 #include "input.h"
+#include "wiipad.h"
 #include <string.h>
 #include "lua.h"
 #include "lauxlib.h"
@@ -161,6 +162,8 @@ void input_mouse_reset(void) {
 
 void input_set_modifier_poll(input_modifier_poll_fn fn) { modifier_poll_fn = fn; }
 
+static void input_wiipad_update(void);  // defined after gamepad_vkeys below
+
 void input_update(void) {
     // Poll USB host so new HID reports are processed
     tuh_task();
@@ -170,6 +173,9 @@ void input_update(void) {
 
     // Poll mouse if registered
     if (mouse_poll_fn) mouse_poll_fn();
+
+    // Poll Wii controller and inject into virtual keycode space
+    input_wiipad_update();
 
     // Update btnp hold counters for each player/button
     for (int p = 0; p < 2; p++) {
@@ -242,6 +248,47 @@ static const uint8_t gamepad_vkeys[2][7] = {
     { VKEY_GP1_LEFT, VKEY_GP1_RIGHT, VKEY_GP1_UP, VKEY_GP1_DOWN, VKEY_GP1_O, VKEY_GP1_X, VKEY_GP1_MENU },
     { VKEY_GP2_LEFT, VKEY_GP2_RIGHT, VKEY_GP2_UP, VKEY_GP2_DOWN, VKEY_GP2_O, VKEY_GP2_X, 0 },
 };
+
+// --- Wii controller ---
+
+// USB controller count poll — determines wiipad player assignment
+static input_usb_ctrl_count_fn usb_ctrl_count_fn = NULL;
+
+void input_set_usb_controller_count_poll(input_usb_ctrl_count_fn fn) {
+    usb_ctrl_count_fn = fn;
+}
+
+// Last player slot the wiipad was assigned to (-1 = not yet assigned).
+// Tracked so we can clear stale vkeys when the assignment changes.
+static int wiipad_player = -1;
+
+static void input_wiipad_update(void) {
+    int usb_count = usb_ctrl_count_fn ? usb_ctrl_count_fn() : 0;
+    int new_player = (usb_count > 0) ? 1 : 0;
+
+    // If the player slot changed, clear all vkeys for the old slot so
+    // nothing gets stuck when a USB controller is plugged or unplugged.
+    if (wiipad_player != -1 && wiipad_player != new_player) {
+        const uint8_t *old_vk = gamepad_vkeys[wiipad_player];
+        for (int i = 0; i < 7; i++) {
+            if (old_vk[i]) key_clear(key_state, old_vk[i]);
+        }
+    }
+    wiipad_player = new_player;
+
+    uint16_t btns = wiipad_read();
+    const uint8_t *vk = gamepad_vkeys[new_player];
+
+    if (btns & WII_BTN_LEFT)  key_set(key_state, vk[0]); else key_clear(key_state, vk[0]);
+    if (btns & WII_BTN_RIGHT) key_set(key_state, vk[1]); else key_clear(key_state, vk[1]);
+    if (btns & WII_BTN_UP)    key_set(key_state, vk[2]); else key_clear(key_state, vk[2]);
+    if (btns & WII_BTN_DOWN)  key_set(key_state, vk[3]); else key_clear(key_state, vk[3]);
+    if (btns & WII_BTN_A)     key_set(key_state, vk[4]); else key_clear(key_state, vk[4]);
+    if (btns & WII_BTN_B)     key_set(key_state, vk[5]); else key_clear(key_state, vk[5]);
+    if (vk[6]) {
+        if (btns & WII_BTN_PLUS) key_set(key_state, vk[6]); else key_clear(key_state, vk[6]);
+    }
+}
 
 void input_gamepad_report(const uint8_t *report, uint16_t len, int player) {
     if (len < 3) return;

--- a/src/input.h
+++ b/src/input.h
@@ -31,6 +31,11 @@ bool input_key(uint8_t keycode);
 typedef uint8_t (*input_modifier_poll_fn)(void);
 void input_set_modifier_poll(input_modifier_poll_fn fn);
 
+// USB controller count poll — used by wiipad player assignment.
+// Register a function that returns the number of USB gamepads currently connected.
+typedef int (*input_usb_ctrl_count_fn)(void);
+void input_set_usb_controller_count_poll(input_usb_ctrl_count_fn fn);
+
 // Get next character from USB keyboard buffer. Returns -1 if empty.
 int input_getchar(void);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,6 +21,7 @@ extern "C" {
 #include "dvi.h"
 #include "input.h"
 #include "audio.h"
+#include "wiipad.h"
 #include "p8_preprocess.h"
 #include "p8_api.h"
 #include "p8_sfx.h"
@@ -803,6 +804,13 @@ int main() {
             input_xinput_update(pad->wButtons, pad->sThumbLX, pad->sThumbLY, player);
         });
 
+    // Register USB controller count poll for wiipad player assignment.
+    // If any USB gamepad is connected, the wiipad becomes player 2.
+    input_set_usb_controller_count_poll([]() -> int {
+        return (int)(obUSBHost.m_obHID.getControllerCount()
+                   + obUSBHost.m_obXInput.getMountedCount());
+    });
+
     printf("\n");
     printf("========================================\n");
     printf("  wili8jam — Lua 5.4.7 on Fruit Jam\n");
@@ -869,6 +877,10 @@ int main() {
         printf("Audio: init failed\n");
         p8_console_print("audio: failed\n");
     }
+
+    // Init Wii controller on STEMMA QT (must be after audio_init — it sets up i2c0)
+    wiipad_init();
+    p8_console_draw(); gfx_flip();
 
     // Init PICO-8 SFX/music engine (wavetables + pitch table)
     p8_sfx_init();

--- a/src/wiipad.c
+++ b/src/wiipad.c
@@ -1,0 +1,94 @@
+#include "wiipad.h"
+#include "hardware/i2c.h"
+#include "pico/stdlib.h"
+#include <stdio.h>
+
+// Wii controller I2C address (Classic, NES Classic, SNES Classic)
+#define WII_ADDR         0x52
+
+// How many frames to wait between re-init attempts when not connected
+#define WII_RETRY_FRAMES 60
+
+static bool wii_connected    = false;
+static int  wii_retry_counter = 0;
+
+// Write a single register on the controller.
+// Returns true on success.
+static bool wii_write_reg(uint8_t reg, uint8_t value) {
+    uint8_t buf[2] = { reg, value };
+    return i2c_write_timeout_us(i2c0, WII_ADDR, buf, 2, false, 3000) == 2;
+}
+
+// Send the "new" initialization sequence that disables encryption.
+// Returns true if the controller acknowledged both writes.
+static bool wii_try_init(void) {
+    if (!wii_write_reg(0xF0, 0x55)) return false;
+    sleep_us(100);
+    if (!wii_write_reg(0xFB, 0x00)) return false;
+    sleep_us(100);
+    return true;
+}
+
+void wiipad_init(void) {
+    // i2c0 is already initialized at 100 kHz on GPIO 20/21 by audio_init()
+    wii_connected     = wii_try_init();
+    wii_retry_counter = 0;
+    if (wii_connected)
+        printf("Wii controller: connected\n");
+    else
+        printf("Wii controller: not found (will retry each %d frames)\n", WII_RETRY_FRAMES);
+}
+
+uint16_t wiipad_read(void) {
+    // If not connected, periodically retry initialization
+    if (!wii_connected) {
+        if (++wii_retry_counter >= WII_RETRY_FRAMES) {
+            wii_retry_counter = 0;
+            wii_connected = wii_try_init();
+            if (wii_connected)
+                printf("Wii controller: connected\n");
+        }
+        return 0;
+    }
+
+    // Request a data burst by writing register 0x00
+    uint8_t req = 0x00;
+    if (i2c_write_timeout_us(i2c0, WII_ADDR, &req, 1, false, 3000) != 1) {
+        wii_connected = false;
+        printf("Wii controller: disconnected\n");
+        return 0;
+    }
+
+    // Allow the controller time to prepare data (~200 µs is sufficient at 100 kHz)
+    sleep_us(200);
+
+    // Read 6 bytes of controller state
+    uint8_t data[6];
+    if (i2c_read_timeout_us(i2c0, WII_ADDR, data, 6, false, 3000) != 6) {
+        wii_connected = false;
+        printf("Wii controller: disconnected\n");
+        return 0;
+    }
+
+    // Decode digital buttons from bytes 4 and 5.
+    // All button bits are active LOW (0 = pressed, 1 = released).
+    //
+    // Byte 4:  BDR(7) BDD(6) BLT(5) B-(4) BH(3) B+(2) BRT(1) 1(0)
+    // Byte 5:  BZL(7) BB(6)  BY(5)  BA(4) BX(3) BZR(2) BDL(1) BDU(0)
+    //
+    // BDR/BDL/BDU/BDD = right/left/up/down on D-pad
+    // BA = A button, BB = B button, B+ = Plus/Start
+    uint8_t b4 = data[4];
+    uint8_t b5 = data[5];
+
+    uint16_t btns = 0;
+    if (!(b5 & 0x02)) btns |= WII_BTN_LEFT;   // BDL  byte5 bit1
+    if (!(b4 & 0x80)) btns |= WII_BTN_RIGHT;  // BDR  byte4 bit7
+    if (!(b5 & 0x01)) btns |= WII_BTN_UP;     // BDU  byte5 bit0
+    if (!(b4 & 0x40)) btns |= WII_BTN_DOWN;   // BDD  byte4 bit6
+    if (!(b5 & 0x10)) btns |= WII_BTN_A;      // BA   byte5 bit4
+    if (!(b5 & 0x40)) btns |= WII_BTN_B;      // BB   byte5 bit6
+    if (!(b4 & 0x04)) btns |= WII_BTN_PLUS;   // B+   byte4 bit2
+
+    return btns;
+}

--- a/src/wiipad.h
+++ b/src/wiipad.h
@@ -1,0 +1,35 @@
+#ifndef WIIPAD_H
+#define WIIPAD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Initialize the Wii controller driver.
+// i2c0 must already be initialized — call after audio_init().
+// Safe to call even if no controller is plugged in; will retry automatically.
+void wiipad_init(void);
+
+// Read current button state. Returns a bitmask of WII_BTN_* flags.
+// Returns 0 if no controller is connected.
+// Handles connection detection and re-init internally; call once per frame.
+uint16_t wiipad_read(void);
+
+// Button bitmask flags returned by wiipad_read()
+// Covers Classic Controller, NES Classic, and SNES Classic.
+#define WII_BTN_LEFT   (1 << 0)   // D-pad left
+#define WII_BTN_RIGHT  (1 << 1)   // D-pad right
+#define WII_BTN_UP     (1 << 2)   // D-pad up
+#define WII_BTN_DOWN   (1 << 3)   // D-pad down
+#define WII_BTN_A      (1 << 4)   // A button  → PICO-8 O (btn 4)
+#define WII_BTN_B      (1 << 5)   // B button  → PICO-8 X (btn 5)
+#define WII_BTN_PLUS   (1 << 6)   // + (Start) → PICO-8 menu (btn 6)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // WIIPAD_H


### PR DESCRIPTION
Adds support for NES Classic, SNES Classic, and Wii Classic Controllers via the STEMMA QT
  port (I2C address 0x52). Reuses the i2c0 bus already initialized by the audio codec. Controller is
  auto-detected and retried every 60 frames. When a USB gamepad is also connected, the Wii controller
  becomes player 2. This is based on https://github.com/fhoedemakers/pico-infonesPlus and uses https://www.adafruit.com/product/4836 to connect